### PR TITLE
Update MSSQL query syntax in read_resource() function

### DIFF
--- a/src/mssql_mcp_server/server.py
+++ b/src/mssql_mcp_server/server.py
@@ -79,7 +79,7 @@ async def read_resource(uri: AnyUrl) -> str:
     try:
         with connect(connection_string) as conn:
             with conn.cursor() as cursor:
-                cursor.execute(f"SELECT * FROM {table} LIMIT 100")
+                cursor.execute(f"SELECT TOP 100 * FROM {table}")
                 columns = [desc[0] for desc in cursor.description]
                 rows = cursor.fetchall()
                 result = [",".join(map(str, row)) for row in rows]


### PR DESCRIPTION
### Description
Updated the SQL query syntax in the `read_resource()` function to use MSSQL-specific syntax. Changed the `LIMIT` clause to `TOP` keyword which is the proper syntax for Microsoft SQL Server.

### Changes Made
```
# Previous code
cursor.execute(f"SELECT * FROM {table} LIMIT 100")

# Updated code
cursor.execute(f"SELECT TOP 100 * FROM {table}")
```

###Reason for Change
Microsoft SQL Server does not support the `LIMIT` keyword which is commonly used in other database systems like MySQL and PostgreSQL. In MSSQL, the `TOP` keyword is used instead to limit the number of rows returned by a query. This change ensures that table data can be properly retrieved from MSSQL databases.