### PR TITLE
fix(server): honour MSSQL_SERVER env var fallback

### DIFF
--- a/src/mssql_mcp_server/server.py
+++ b/src/mssql_mcp_server/server.py
@@ -17,7 +17,7 @@ def get_db_config():
     """Get database configuration from environment variables."""
     config = {
         "driver": os.getenv("MSSQL_DRIVER", "SQL Server"),
-        "server": os.getenv("MSSQL_HOST", "localhost"),
+        "server": os.getenv("MSSQL_HOST") or os.getenv("MSSQL_SERVER") or "localhost",
         "user": os.getenv("MSSQL_USER"),
         "password": os.getenv("MSSQL_PASSWORD"),
         "database": os.getenv("MSSQL_DATABASE"),


### PR DESCRIPTION
MSSQL_SERVER was used by dependent projects but ignored by get_db_config(). The new lookup chain resolves that mismatch (`MSSQL_HOST` → `MSSQL_SERVER` → default localhost)."

### Problem
`get_db_config()` only reads MSSQL_HOST, yet many examples (and
the companion medinsight project) export MSSQL_SERVER. This makes
the server silently fall back to `localhost`, causing login
timeouts.

### Fix
Add a fallback: `MSSQL_HOST` → `MSSQL_SERVER` → default.

### Notes
* No breaking change – existing configs keep working.
* All tests pass (`pytest -q`).